### PR TITLE
do not use list columns for arrage

### DIFF
--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -1,0 +1,17 @@
+context("test-internals.R")
+
+test_that("choose_col_for_filter_and_arrange() works", {
+  d1 <- tibble::tibble(x = 1,
+                       y = "a",
+                       z = factor("a"),
+                       p1 = TRUE,
+                       lst = list(1, 2))
+
+  expected <- list(filter = rlang::syms(c("p1")),
+                   arrange = rlang::syms(c("y", "z")))
+  expect_equal(choose_col_for_filter_and_arrange(d1, rlang::sym("x")),
+               !!expected)
+
+  expect_equal(choose_col_for_filter_and_arrange(d1, rlang::quo(x)),
+               !!expected)
+})


### PR DESCRIPTION
Close #35 

Now this is possible:

``` r
library(ggplot2)

nc <- sf::st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)

p1 <- ggplot(nc) +
  geom_sf(aes(fill = AREA)) +
  ggtitle("All")

library(gghighlight)

p2 <- p1 + geom_highlight(grepl("^A", NAME)) +
  ggtitle("Polygons that starts with A")
#> Warning: You set use_group_by = TRUE, but grouped calculation failed.
#> Falling back to ungrouped filter operation...

library(patchwork)

p1 + p2
```

![](https://i.imgur.com/rzDtofO.png)

Created on 2018-05-29 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).
