### PR TITLE
Pass parameters to ggrepel

### DIFF
--- a/R/geom_highlight.R
+++ b/R/geom_highlight.R
@@ -7,13 +7,15 @@
 #' @param max_highlight
 #'   Max number of series to highlight.
 #' @param unhighlighted_colour
-#'   Colour for unhighlited lines/points.
+#'   Colour for unhighlited geoms.
 #' @param use_group_by
 #'   If `TRUE`, use [dplyr::group_by()] to evaluate `predicate`.
 #' @param use_direct_label
 #'   If `TRUE`, add labels directly on the plot instead of using a legend.
 #' @param label_key
 #'   Column name for `label` aesthetics.
+#' @param label_params
+#'   A list of parameters, which is passed to [ggrepel::geom_label_repel()].
 #' @export
 geom_highlight <- function(...,
                            n = NULL,
@@ -21,7 +23,8 @@ geom_highlight <- function(...,
                            unhighlighted_colour = ggplot2::alpha("grey", 0.7),
                            use_group_by = NULL,
                            use_direct_label = NULL,
-                           label_key = NULL) {
+                           label_key = NULL,
+                           label_params = list(fill = "white")) {
 
   # if use_direct_label is NULL, try to use direct labels but ignore failures
   # if use_direct_label is TRUE, use direct labels, otherwise stop()
@@ -41,7 +44,8 @@ geom_highlight <- function(...,
       use_group_by = use_group_by,
       use_direct_label = use_direct_label,
       label_key_must_exist = label_key_must_exist,
-      label_key = rlang::enquo(label_key)
+      label_key = rlang::enquo(label_key),
+      label_params = label_params
     ),
     class = "gg_highlighter"
   )
@@ -112,7 +116,8 @@ ggplot_add.gg_highlighter <- function(object, plot, object_name) {
     return(plot)
   }
 
-  layer_labelled <- generate_labelled_layer(layers_sieved, group_infos, object$label_key)
+  layer_labelled <- generate_labelled_layer(layers_sieved, group_infos,
+                                            object$label_key, object$label_params)
 
   if (is.null(layer_labelled)) {
     if (object$label_key_must_exist) {

--- a/man/geom_highlight.Rd
+++ b/man/geom_highlight.Rd
@@ -6,7 +6,8 @@
 \usage{
 geom_highlight(..., n = NULL, max_highlight = 5L,
   unhighlighted_colour = ggplot2::alpha("grey", 0.7), use_group_by = NULL,
-  use_direct_label = NULL, label_key = NULL)
+  use_direct_label = NULL, label_key = NULL, label_params = list(fill =
+  "white"))
 }
 \arguments{
 \item{...}{Expressions to filter data, which is passed to \code{\link[dplyr:filter]{dplyr::filter()}}.}
@@ -15,13 +16,15 @@ geom_highlight(..., n = NULL, max_highlight = 5L,
 
 \item{max_highlight}{Max number of series to highlight.}
 
-\item{unhighlighted_colour}{Colour for unhighlited lines/points.}
+\item{unhighlighted_colour}{Colour for unhighlited geoms.}
 
 \item{use_group_by}{If \code{TRUE}, use \code{\link[dplyr:group_by]{dplyr::group_by()}} to evaluate \code{predicate}.}
 
 \item{use_direct_label}{If \code{TRUE}, add labels directly on the plot instead of using a legend.}
 
 \item{label_key}{Column name for \code{label} aesthetics.}
+
+\item{label_params}{A list of parameters, which is passed to \code{\link[ggrepel:geom_label_repel]{ggrepel::geom_label_repel()}}.}
 }
 \description{
 Clone Other Layers

--- a/tests/testthat/test-geom_highlight.R
+++ b/tests/testthat/test-geom_highlight.R
@@ -270,7 +270,7 @@ test_that("geom_highlight() works the plot with one layer, grouped", {
     dplyr::slice(1) %>%
     dplyr::ungroup()
 
-  l_label <- ggrepel::geom_label_repel(aes(x, y, colour = type, label = type), d_label)
+  l_label <- ggrepel::geom_label_repel(aes(x, y, colour = type, label = type), d_label, fill = "white")
   for (p in list(p1, p2, p3)) {
     p_highlighted <- p + geom_highlight(mean(value) > 1, use_direct_label = TRUE)
     expect_equal(p_highlighted$data, d_sieved)

--- a/tests/testthat/test-label.R
+++ b/tests/testthat/test-label.R
@@ -68,16 +68,23 @@ test_that("choose_layer_for_label() chooses a layer properly", {
 })
 
 test_that("generate_labelled_layer() geenrates a layer for label.", {
-  expect_equal(generate_labelled_layer(list(l_point), list(g_info), type2_quo),
-               ggrepel::geom_label_repel(aes(x, y, colour = type, label = type2), d))
+  expect_equal(generate_labelled_layer(list(l_point), list(g_info), type2_quo, list(fill = "white")),
+               ggrepel::geom_label_repel(aes(x, y, colour = type, label = type2), d, fill = "white"))
   # it accepts call
-  expect_equal(generate_labelled_layer(list(l_point), list(g_info), rlang::quo(factor(type2))),
-               ggrepel::geom_label_repel(aes(x, y, colour = type, label = factor(type2)), d))
+  expect_equal(generate_labelled_layer(list(l_point), list(g_info), rlang::quo(factor(type2)), list(fill = "white")),
+               ggrepel::geom_label_repel(aes(x, y, colour = type, label = factor(type2)), d, fill = "white"))
 
-  expect_equal(generate_labelled_layer(list(l_point), list(g_info), rlang::quo(no_such_column)),
+  expect_equal(generate_labelled_layer(list(l_point), list(g_info), rlang::quo(no_such_column), list(fill = "white")),
                NULL)
-  expect_equal(generate_labelled_layer(list(l_line), list(g_info), type2_quo),
-               ggrepel::geom_label_repel(aes(x, y, colour = type, label = type2), d[c(2, 4), ]))
-  expect_equal(generate_labelled_layer(list(l_bar), list(g_info), type2_quo),
+  expect_equal(generate_labelled_layer(list(l_line), list(g_info), type2_quo, list(fill = "white")),
+               ggrepel::geom_label_repel(aes(x, y, colour = type, label = type2), d[c(2, 4), ], fill = "white"))
+  expect_equal(generate_labelled_layer(list(l_bar), list(g_info), type2_quo, list(fill = "white")),
                list())
+})
+
+test_that("call_ggrepel_with_params() generates a geom_label_repel()", {
+  expect_equal(
+    call_ggrepel_with_params(aes(x, y, colour = type, label = type), d, list(fill = "white")),
+    ggrepel::geom_label_repel(aes(x, y, colour = type, label = type), d, fill = "white")
+  )
 })


### PR DESCRIPTION
Add `label_params` argument and set the default to `list(fill = "white")`.

Fixes #8, #44 

``` r
library(gghighlight)
library(ggplot2)

d <- tibble::tribble(
  ~x, ~y, ~type, ~value,
  1,  2,   "a",     0,
  2,  3,   "a",     1,
  3,  4,   "a",     0,
  1,  3,   "b",     1,
  2,  2,   "b",     5,
  1,  4,   "c",    10,
  3,  3,   "c",    10
)
ggplot(d, aes(x, y, colour = type, fill = type)) +
  geom_line() +
  geom_point(shape = "circle filled") +
  geom_highlight(mean(value) > 1, use_direct_label = TRUE)
#> label_key: type
```

![](https://i.imgur.com/xRDSQTD.png)

Created on 2018-06-02 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).
