### PR TITLE
respect default NA

### DIFF
--- a/tests/testthat/test-geom_highlight.R
+++ b/tests/testthat/test-geom_highlight.R
@@ -94,6 +94,10 @@ test_that("bleach_layer() works", {
   expect_equal_layer(bleach_layer(geom_bar(aes(colour = type), d), g_info, grey07),
                      geom_bar(aes_bleached, d_bleached, colour = grey07, fill = grey07))
 
+  # If the default of colour of the geom is NA and mapping doesn't specify it, params will be NA.
+  expect_equal_layer(bleach_layer(geom_bar(aes(fill = type), d), g_info, grey07),
+                     geom_bar(aes_bleached, d_bleached, colour = NA, fill = grey07))
+
   # If colour and fill is specified at the same time, fill is used as the group key.
   expect_equal_layer(bleach_layer(geom_bar(aes(colour = type, fill = type), d), g_info, grey07),
                      geom_bar(aes_bleached, d_bleached, colour = grey07, fill = grey07))
@@ -101,9 +105,9 @@ test_that("bleach_layer() works", {
   # If mapping doesn't have colour or fill, group or x aes can be used as group key.
   # c.f. https://github.com/yutannihilation/gghighlight/pull/17#issuecomment-390486101.
   expect_equal_layer(bleach_layer(geom_bar(aes(group = type), d), g_info, grey07),
-                     geom_bar(aes_bleached, d_bleached, colour = grey07, fill = grey07))
+                     geom_bar(aes_bleached, d_bleached, colour = NA, fill = grey07))
   expect_equal_layer(bleach_layer(geom_bar(aes(x = type), d), g_info, grey07),
-                     geom_bar(aes_bleached, d_bleached, colour = grey07, fill = grey07))
+                     geom_bar(aes_bleached, d_bleached, colour = NA, fill = grey07))
 })
 
 test_that("sieve_layer() works with simple cases", {
@@ -280,7 +284,8 @@ test_that("geom_highlight() works the plot with one layer, grouped", {
 })
 
 test_that("geom_highlight() works the plot with one layer, ungrouped", {
-  l_bleached <- geom_point(aes_bleached, d_bleached, colour = grey07, fill = grey07)
+  # Note that the default_aes of fill of point is NA
+  l_bleached <- geom_point(aes_bleached, d_bleached, colour = grey07, fill = NA)
   l_sieved <- geom_point(aes(x, y, colour = type), d[d$value > 1, ])
 
   p1 <- ggplot(d, aes(x, y, colour = type)) +
@@ -343,10 +348,10 @@ test_that("geom_highlight() works with two layers, ungrouped", {
   d_sieved <- d[d$value > 1, ]
 
   l_bleached_1 <- geom_point(aes_bleached, d_bleached, shape = "circle open", size = 5,
-                             colour = grey07, fill = grey07)
+                             colour = grey07, fill = NA)
   l_sieved_1 <- geom_point(aes(x, y, colour = type), d_sieved, shape = "circle open", size = 5)
   l_bleached_2 <- geom_point(aes_bleached, d_bleached,
-                             colour = grey07, fill = grey07)
+                             colour = grey07, fill = NA)
   l_sieved_2 <- geom_point(aes(x, y, colour = type), d_sieved)
 
   p1 <- ggplot(d, aes(x, y, colour = type)) +


### PR DESCRIPTION
Fix #39 

### Current

``` r
library(ggplot2)
library(gghighlight)
library(patchwork)

p1 <- ggplot(diamonds, aes(depth, colour = cut)) +
  geom_density() +
  xlim(55, 70)

# fill is also specified
p2 <- ggplot(diamonds, aes(depth, colour = cut, fill = cut)) +
  geom_density(alpha = 0.5) +
  xlim(55, 70)

p1 / (p1 + geom_highlight(max(depth) > 65))
#> Warning: Removed 45 rows containing non-finite values (stat_density).

#> Warning: Removed 45 rows containing non-finite values (stat_density).

#> Warning: Removed 45 rows containing non-finite values (stat_density).
```

![](https://i.imgur.com/SrWTcmL.png)

``` r
p2 / (p2 + geom_highlight(max(depth) > 65))
#> Warning: Removed 45 rows containing non-finite values (stat_density).

#> Warning: Removed 45 rows containing non-finite values (stat_density).

#> Warning: Removed 45 rows containing non-finite values (stat_density).
```

![](https://i.imgur.com/1XMpJWV.png)

Created on 2018-06-02 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).


### PR

``` r
library(ggplot2)
library(gghighlight)
library(patchwork)

p1 <- ggplot(diamonds, aes(depth, colour = cut)) +
  geom_density() +
  xlim(55, 70)

# fill is also specified
p2 <- ggplot(diamonds, aes(depth, colour = cut, fill = cut)) +
  geom_density(alpha = 0.5) +
  xlim(55, 70)

p1 / (p1 + geom_highlight(max(depth) > 65))
#> Warning: Removed 45 rows containing non-finite values (stat_density).

#> Warning: Removed 45 rows containing non-finite values (stat_density).

#> Warning: Removed 45 rows containing non-finite values (stat_density).
```

![](https://i.imgur.com/fldacSV.png)

``` r
p2 / (p2 + geom_highlight(max(depth) > 65))
#> Warning: Removed 45 rows containing non-finite values (stat_density).

#> Warning: Removed 45 rows containing non-finite values (stat_density).

#> Warning: Removed 45 rows containing non-finite values (stat_density).
```

![](https://i.imgur.com/9L8cz95.png)

Created on 2018-06-02 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).
