### PR TITLE
Enable to control more aesthetics in bleached layer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
   rlang
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.1
 Suggests: 
     testthat,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # gghighlight 0.1.0.9000
 
+* `gghighlight()` gets a new argument `unhighlighted_params`, which accepts a
+  list of parameters for the unhighlighted layer (e.g. `colour`, `fill`, `shape`,
+  and `size`). Accordingly, `unhighlighted_colour` is deprecated (#76).
+
 # gghighlight 0.1.0
 
 * Add `gghighlight()`, which replaces the current `gghighlight_line()` and `gghighlight_point()`; these functions are now deprecated.

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -389,11 +389,14 @@ normalize_unhighlighted_aes <- function(aes_params) {
     aes_params$color <- NULL
   }
 
-  # if fill or colour is missing, use the other for it
+  # if both fill and colour are missing, use the default value
   if (is.null(aes_params$colour) && is.null(aes_params$fill)) {
-    rlang::abort("unhighlighted_aes must contain at least either of colour or fill.")
+    aes_params$colour <- ggplot2::alpha("grey", 0.7)
+    aes_params$fill <- ggplot2::alpha("grey", 0.7)
+    return(aes_params)
   }
 
+  # if fill or colour is missing, use the other for it
   aes_params$colour <- aes_params$colour %||% aes_params$fill
   aes_params$fill <- aes_params$fill %||% aes_params$colour
   aes_params

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -10,7 +10,7 @@
 #'   Number of layers to clone.
 #' @param max_highlight
 #'   Max number of series to highlight.
-#' @param unhighlighted_aes
+#' @param unhighlighted_params
 #'   Aesthetics (e.g. colour, fill, and size) for unhighlighted geoms.
 #' @param use_group_by
 #'   If `TRUE`, use [dplyr::group_by()] to evaluate `predicate`.
@@ -44,7 +44,7 @@
 gghighlight <- function(...,
                         n = NULL,
                         max_highlight = 5L,
-                        unhighlighted_aes = list(colour = ggplot2::alpha("grey", 0.7)),
+                        unhighlighted_params = list(colour = ggplot2::alpha("grey", 0.7)),
                         use_group_by = NULL,
                         use_direct_label = NULL,
                         label_key = NULL,
@@ -61,11 +61,11 @@ gghighlight <- function(...,
   }
 
   # if fill is not specified, use colour for fill, or vice versa
-  unhighlighted_aes <- normalize_unhighlighted_aes(unhighlighted_aes)
+  unhighlighted_params <- normalize_unhighlighted_params(unhighlighted_params)
 
   if (!is.null(unhighlighted_colour)) {
-    rlang::warn("unhighlighted_colour is deprecated. Use unhighlighted_aes instead.")
-    unhighlighted_aes$colour <- unhighlighted_colour
+    rlang::warn("unhighlighted_colour is deprecated. Use unhighlighted_params instead.")
+    unhighlighted_params$colour <- unhighlighted_colour
   }
 
   structure(
@@ -73,7 +73,7 @@ gghighlight <- function(...,
       predicates = rlang::enquos(...),
       n = n,
       max_highlight = max_highlight,
-      unhighlighted_aes = unhighlighted_aes,
+      unhighlighted_params = unhighlighted_params,
       use_group_by = use_group_by,
       use_direct_label = use_direct_label,
       label_key_must_exist = label_key_must_exist,
@@ -126,7 +126,7 @@ ggplot_add.gg_highlighter <- function(object, plot, object_name) {
     layers_bleached,
     group_infos,
     bleach_layer,
-    unhighlighted_aes = object$unhighlighted_aes
+    unhighlighted_params = object$unhighlighted_params
   )
 
   # Sieve the upper layer.
@@ -226,16 +226,16 @@ calculate_group_info <- function(data, mapping) {
   }
 }
 
-bleach_layer <- function(layer, group_info, unhighlighted_aes) {
+bleach_layer <- function(layer, group_info, unhighlighted_params) {
 
   # c.f. https://github.com/tidyverse/ggplot2/blob/e9d4e5dd599b9f058cbe9230a6517f85f3587567/R/layer.r#L107-L108
-  aes_params_bleached <- unhighlighted_aes[names(unhighlighted_aes) %in% layer$geom$aesthetics()]
-  geom_params_bleached <- unhighlighted_aes[names(unhighlighted_aes) %in% layer$geom$parameters(TRUE)]
+  aes_params_bleached <- unhighlighted_params[names(unhighlighted_params) %in% layer$geom$aesthetics()]
+  geom_params_bleached <- unhighlighted_params[names(unhighlighted_params) %in% layer$geom$parameters(TRUE)]
 
-  # Use the colour and fill specified in unhighlighted_aes when it is included in
+  # Use the colour and fill specified in unhighlighted_params when it is included in
   # the mappping. But, if the default_aes is NA, respect it.
   # (Note that this needs to be executed before modifying the layer$mapping)
-  aes_params_bleached <- fill_unhighlighted_aes_with_na(aes_params_bleached, layer$geom, layer$mapping)
+  aes_params_bleached <- fill_unhighlighted_params_with_na(aes_params_bleached, layer$geom, layer$mapping)
 
   layer$aes_params <- utils::modifyList(layer$aes_params, aes_params_bleached)
   layer$geom_params <- utils::modifyList(layer$geom_params, geom_params_bleached)
@@ -264,17 +264,17 @@ bleach_layer <- function(layer, group_info, unhighlighted_aes) {
   layer
 }
 
-fill_unhighlighted_aes_with_na <- function(unhighlighted_aes, geom, mapping) {
-  aes_name <- names(unhighlighted_aes)
+fill_unhighlighted_params_with_na <- function(unhighlighted_params, geom, mapping) {
+  aes_name <- names(unhighlighted_params)
 
   # if aes_name is not specified in the mapping and the default_aes is NA, use NA.
   is_default_na <- !aes_name %in% names(mapping) &
     aes_name %in% names(geom$default_aes) &
     is.na(geom$default_aes[aes_name])
 
-  unhighlighted_aes[is_default_na] <- NA
+  unhighlighted_params[is_default_na] <- NA
 
-  unhighlighted_aes
+  unhighlighted_params
 }
 
 sieve_layer <- function(layer, group_info, predicates,
@@ -378,9 +378,9 @@ choose_col_for_filter_and_arrange <- function(data, exclude_col) {
   )
 }
 
-normalize_unhighlighted_aes <- function(aes_params) {
+normalize_unhighlighted_params <- function(aes_params) {
   if (!is.list(aes_params)) {
-    rlang::abort("unhighlighted_aes must be a list.")
+    rlang::abort("unhighlighted_params must be a list.")
   }
 
   # color is an alias of colour

--- a/man/gghighlight-old.Rd
+++ b/man/gghighlight-old.Rd
@@ -7,14 +7,14 @@
 \title{Highlight Data With Predicate}
 \usage{
 gghighlight_line(data, mapping, predicate, max_highlight = 5L,
-  unhighlighted_colour = ggplot2::alpha("grey", 0.7), use_group_by = TRUE,
-  use_direct_label = TRUE, label_key = NULL, ...,
-  environment = parent.frame())
+  unhighlighted_colour = ggplot2::alpha("grey", 0.7),
+  use_group_by = TRUE, use_direct_label = TRUE, label_key = NULL,
+  ..., environment = parent.frame())
 
 gghighlight_point(data, mapping, predicate, max_highlight = 5L,
-  unhighlighted_colour = ggplot2::alpha("grey", 0.7), use_group_by = FALSE,
-  use_direct_label = TRUE, label_key = NULL, ...,
-  environment = parent.frame())
+  unhighlighted_colour = ggplot2::alpha("grey", 0.7),
+  use_group_by = FALSE, use_direct_label = TRUE, label_key = NULL,
+  ..., environment = parent.frame())
 }
 \arguments{
 \item{data}{Default dataset to use for plot. If not already a data.frame,

--- a/man/gghighlight.Rd
+++ b/man/gghighlight.Rd
@@ -5,7 +5,7 @@
 \title{Highlight Data With Predicate}
 \usage{
 gghighlight(..., n = NULL, max_highlight = 5L,
-  unhighlighted_aes = list(colour = ggplot2::alpha("grey", 0.7)),
+  unhighlighted_params = list(colour = ggplot2::alpha("grey", 0.7)),
   use_group_by = NULL, use_direct_label = NULL, label_key = NULL,
   label_params = list(fill = "white"), unhighlighted_colour = NULL)
 }
@@ -16,7 +16,7 @@ gghighlight(..., n = NULL, max_highlight = 5L,
 
 \item{max_highlight}{Max number of series to highlight.}
 
-\item{unhighlighted_aes}{Aesthetics (e.g. colour, fill, and size) for unhighlighted geoms.}
+\item{unhighlighted_params}{Aesthetics (e.g. colour, fill, and size) for unhighlighted geoms.}
 
 \item{use_group_by}{If \code{TRUE}, use \code{\link[dplyr:group_by]{dplyr::group_by()}} to evaluate \code{predicate}.}
 

--- a/man/gghighlight.Rd
+++ b/man/gghighlight.Rd
@@ -5,9 +5,9 @@
 \title{Highlight Data With Predicate}
 \usage{
 gghighlight(..., n = NULL, max_highlight = 5L,
-  unhighlighted_colour = ggplot2::alpha("grey", 0.7), use_group_by = NULL,
-  use_direct_label = NULL, label_key = NULL, label_params = list(fill =
-  "white"))
+  unhighlighted_aes = list(colour = ggplot2::alpha("grey", 0.7)),
+  use_group_by = NULL, use_direct_label = NULL, label_key = NULL,
+  label_params = list(fill = "white"), unhighlighted_colour = NULL)
 }
 \arguments{
 \item{...}{Expressions to filter data, which is passed to \code{\link[dplyr:filter]{dplyr::filter()}}.}
@@ -16,7 +16,7 @@ gghighlight(..., n = NULL, max_highlight = 5L,
 
 \item{max_highlight}{Max number of series to highlight.}
 
-\item{unhighlighted_colour}{Colour for unhighlighted geoms.}
+\item{unhighlighted_aes}{Aesthetics (e.g. colour, fill, and size) for unhighlighted geoms.}
 
 \item{use_group_by}{If \code{TRUE}, use \code{\link[dplyr:group_by]{dplyr::group_by()}} to evaluate \code{predicate}.}
 
@@ -25,6 +25,8 @@ gghighlight(..., n = NULL, max_highlight = 5L,
 \item{label_key}{Column name for \code{label} aesthetics.}
 
 \item{label_params}{A list of parameters, which is passed to \code{\link[ggrepel:geom_label_repel]{ggrepel::geom_label_repel()}}.}
+
+\item{unhighlighted_colour}{(Deprecated) Colour for unhighlighted geoms.}
 }
 \description{
 \code{gghiglight()} highlights (almost) any geoms according to the given predicates.

--- a/man/gghighlight.Rd
+++ b/man/gghighlight.Rd
@@ -5,9 +5,9 @@
 \title{Highlight Data With Predicate}
 \usage{
 gghighlight(..., n = NULL, max_highlight = 5L,
-  unhighlighted_params = list(colour = ggplot2::alpha("grey", 0.7)),
-  use_group_by = NULL, use_direct_label = NULL, label_key = NULL,
-  label_params = list(fill = "white"), unhighlighted_colour = NULL)
+  unhighlighted_params = list(), use_group_by = NULL,
+  use_direct_label = NULL, label_key = NULL, label_params = list(fill
+  = "white"), unhighlighted_colour = NULL)
 }
 \arguments{
 \item{...}{Expressions to filter data, which is passed to \code{\link[dplyr:filter]{dplyr::filter()}}.}

--- a/tests/testthat/test-gghighlight.R
+++ b/tests/testthat/test-gghighlight.R
@@ -88,7 +88,7 @@ aes_bleached <- aes_string(x = paste0(prefix, 1),
                            group = paste0(prefix, "group"))
 
 test_that("bleach_layer() works", {
-  aes_grey07 <- normalize_unhighlighted_aes(list(colour = grey07))
+  aes_grey07 <- normalize_unhighlighted_params(list(colour = grey07))
 
   # If colour is specified, colour is used as the group key.
   expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), g_info, aes_grey07),
@@ -117,8 +117,8 @@ test_that("bleach_layer() works", {
   expect_equal_layer(bleach_layer(geom_col(aes(x = type), d), g_info, aes_grey07),
                      geom_col(aes_bleached, d_bleached, colour = NA, fill = grey07))
 
-  # unhighlighted_aes can be more detailed
-  aes_grey07_and_more <- normalize_unhighlighted_aes(list(colour = grey09, fill = grey07, width = 0.5))
+  # unhighlighted_params can be more detailed
+  aes_grey07_and_more <- normalize_unhighlighted_params(list(colour = grey09, fill = grey07, width = 0.5))
 
   expect_equal_layer(bleach_layer(geom_col(aes(colour = type, fill = type), d), g_info, aes_grey07_and_more),
                      geom_col(aes_bleached, d_bleached, colour = grey09, fill = grey07, width = 0.5))

--- a/tests/testthat/test-gghighlight.R
+++ b/tests/testthat/test-gghighlight.R
@@ -88,30 +88,30 @@ aes_bleached <- aes_string(x = paste0(prefix, 1),
 
 test_that("bleach_layer() works", {
   # If colour is specified, colour is used as the group key.
-  expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), g_info, grey07),
+  expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), g_info, list(colour = grey07)),
                      geom_line(aes_bleached, d_bleached, colour = grey07))
 
   # If colour is specified but group_key is NULL, the result is the same data.
-  expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), NULL, grey07),
+  expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), NULL, list(colour = grey07)),
                      geom_line(aes(colour = NULL, fill = NULL), d, colour = grey07))
 
   # If the geom accepts fill, it is sets to grey even when it is not included in the mapping.
-  expect_equal_layer(bleach_layer(geom_bar(aes(colour = type), d), g_info, grey07),
+  expect_equal_layer(bleach_layer(geom_bar(aes(colour = type), d), g_info, list(colour = grey07)),
                      geom_bar(aes_bleached, d_bleached, colour = grey07, fill = grey07))
 
   # If the default of colour of the geom is NA and mapping doesn't specify it, params will be NA.
-  expect_equal_layer(bleach_layer(geom_bar(aes(fill = type), d), g_info, grey07),
+  expect_equal_layer(bleach_layer(geom_bar(aes(fill = type), d), g_info, list(colour = grey07)),
                      geom_bar(aes_bleached, d_bleached, colour = NA, fill = grey07))
 
   # If colour and fill is specified at the same time, fill is used as the group key.
-  expect_equal_layer(bleach_layer(geom_bar(aes(colour = type, fill = type), d), g_info, grey07),
+  expect_equal_layer(bleach_layer(geom_bar(aes(colour = type, fill = type), d), g_info, list(colour = grey07)),
                      geom_bar(aes_bleached, d_bleached, colour = grey07, fill = grey07))
 
   # If mapping doesn't have colour or fill, group or x aes can be used as group key.
   # c.f. https://github.com/yutannihilation/gghighlight/pull/17#issuecomment-390486101.
-  expect_equal_layer(bleach_layer(geom_bar(aes(group = type), d), g_info, grey07),
+  expect_equal_layer(bleach_layer(geom_bar(aes(group = type), d), g_info, list(colour = grey07)),
                      geom_bar(aes_bleached, d_bleached, colour = NA, fill = grey07))
-  expect_equal_layer(bleach_layer(geom_bar(aes(x = type), d), g_info, grey07),
+  expect_equal_layer(bleach_layer(geom_bar(aes(x = type), d), g_info, list(colour = grey07)),
                      geom_bar(aes_bleached, d_bleached, colour = NA, fill = grey07))
 })
 

--- a/tests/testthat/test-gghighlight.R
+++ b/tests/testthat/test-gghighlight.R
@@ -2,6 +2,7 @@ context("test-gghighlight.R")
 library(ggplot2)
 
 grey07 <- ggplot2::alpha("grey", 0.7)
+grey09 <- ggplot2::alpha("grey", 0.9)
 
 d <- tibble::tribble(
   ~x, ~y, ~type, ~value,
@@ -87,32 +88,40 @@ aes_bleached <- aes_string(x = paste0(prefix, 1),
                            group = paste0(prefix, "group"))
 
 test_that("bleach_layer() works", {
+  aes_grey07 <- normalize_unhighlighted_aes(list(colour = grey07))
+
   # If colour is specified, colour is used as the group key.
-  expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), g_info, list(colour = grey07)),
+  expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), g_info, aes_grey07),
                      geom_line(aes_bleached, d_bleached, colour = grey07))
 
   # If colour is specified but group_key is NULL, the result is the same data.
-  expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), NULL, list(colour = grey07)),
+  expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), NULL, aes_grey07),
                      geom_line(aes(colour = NULL, fill = NULL), d, colour = grey07))
 
   # If the geom accepts fill, it is sets to grey even when it is not included in the mapping.
-  expect_equal_layer(bleach_layer(geom_bar(aes(colour = type), d), g_info, list(colour = grey07)),
-                     geom_bar(aes_bleached, d_bleached, colour = grey07, fill = grey07))
+  expect_equal_layer(bleach_layer(geom_col(aes(colour = type), d), g_info, aes_grey07),
+                     geom_col(aes_bleached, d_bleached, colour = grey07, fill = grey07))
 
   # If the default of colour of the geom is NA and mapping doesn't specify it, params will be NA.
-  expect_equal_layer(bleach_layer(geom_bar(aes(fill = type), d), g_info, list(colour = grey07)),
-                     geom_bar(aes_bleached, d_bleached, colour = NA, fill = grey07))
+  expect_equal_layer(bleach_layer(geom_col(aes(fill = type), d), g_info, aes_grey07),
+                     geom_col(aes_bleached, d_bleached, colour = NA, fill = grey07))
 
   # If colour and fill is specified at the same time, fill is used as the group key.
-  expect_equal_layer(bleach_layer(geom_bar(aes(colour = type, fill = type), d), g_info, list(colour = grey07)),
-                     geom_bar(aes_bleached, d_bleached, colour = grey07, fill = grey07))
+  expect_equal_layer(bleach_layer(geom_col(aes(colour = type, fill = type), d), g_info, aes_grey07),
+                     geom_col(aes_bleached, d_bleached, colour = grey07, fill = grey07))
 
   # If mapping doesn't have colour or fill, group or x aes can be used as group key.
   # c.f. https://github.com/yutannihilation/gghighlight/pull/17#issuecomment-390486101.
-  expect_equal_layer(bleach_layer(geom_bar(aes(group = type), d), g_info, list(colour = grey07)),
-                     geom_bar(aes_bleached, d_bleached, colour = NA, fill = grey07))
-  expect_equal_layer(bleach_layer(geom_bar(aes(x = type), d), g_info, list(colour = grey07)),
-                     geom_bar(aes_bleached, d_bleached, colour = NA, fill = grey07))
+  expect_equal_layer(bleach_layer(geom_col(aes(group = type), d), g_info, aes_grey07),
+                     geom_col(aes_bleached, d_bleached, colour = NA, fill = grey07))
+  expect_equal_layer(bleach_layer(geom_col(aes(x = type), d), g_info, aes_grey07),
+                     geom_col(aes_bleached, d_bleached, colour = NA, fill = grey07))
+
+  # unhighlighted_aes can be more detailed
+  aes_grey07_and_more <- normalize_unhighlighted_aes(list(colour = grey09, fill = grey07, width = 0.5))
+
+  expect_equal_layer(bleach_layer(geom_col(aes(colour = type, fill = type), d), g_info, aes_grey07_and_more),
+                     geom_col(aes_bleached, d_bleached, colour = grey09, fill = grey07, width = 0.5))
 })
 
 test_that("sieve_layer() works with simple cases", {

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -15,3 +15,29 @@ test_that("choose_col_for_filter_and_arrange() works", {
   expect_equal(choose_col_for_filter_and_arrange(d1, rlang::quo(x)),
                !!expected)
 })
+
+test_that("normalize_unhighlighted_aes() works", {
+  expect_listequal <- function(x, y) {
+    expect_equal(!!x[sort(names(x))], !!y[sort(names(y))])
+  }
+
+  # if fill or colour is missing, use the other for it
+  expect_listequal(normalize_unhighlighted_aes(list(colour = "red")),
+                   list(colour = "red", fill = "red"))
+  expect_listequal(normalize_unhighlighted_aes(list(fill = "red")),
+                   list(colour = "red", fill = "red"))
+  # if fill and colour is specified, respect both
+  expect_listequal(normalize_unhighlighted_aes(list(colour = "blue", fill = "red")),
+                   list(colour = "blue", fill = "red"))
+  # other parameters are left as is
+  expect_listequal(normalize_unhighlighted_aes(list(fill = "red", size = 0.2)),
+                   list(colour = "red", fill = "red", size = 0.2))
+  # color is an alias of colour
+  expect_listequal(normalize_unhighlighted_aes(list(color = "red")),
+                   list(colour = "red", fill = "red"))
+  # if both colour and color are specified, use colour.
+  expect_listequal(normalize_unhighlighted_aes(list(colour = "blue", color = "red")),
+                   list(colour = "blue", fill = "blue"))
+  # if both fill and colour are missing, raise error
+  expect_error(normalize_unhighlighted_aes(list()))
+})

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -39,5 +39,6 @@ test_that("normalize_unhighlighted_aes() works", {
   expect_listequal(normalize_unhighlighted_aes(list(colour = "blue", color = "red")),
                    list(colour = "blue", fill = "blue"))
   # if both fill and colour are missing, raise error
-  expect_error(normalize_unhighlighted_aes(list()))
+  expect_listequal(normalize_unhighlighted_aes(list()),
+                   list(colour = ggplot2::alpha("grey", 0.7), fill = ggplot2::alpha("grey", 0.7)))
 })

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -21,24 +21,16 @@ test_that("normalize_unhighlighted_params() works", {
     expect_equal(!!x[sort(names(x))], !!y[sort(names(y))])
   }
 
-  # if fill or colour is missing, use the other for it
-  expect_listequal(normalize_unhighlighted_params(list(colour = "red")),
-                   list(colour = "red", fill = "red"))
-  expect_listequal(normalize_unhighlighted_params(list(fill = "red")),
-                   list(colour = "red", fill = "red"))
   # if fill and colour is specified, respect both
   expect_listequal(normalize_unhighlighted_params(list(colour = "blue", fill = "red")),
                    list(colour = "blue", fill = "red"))
   # other parameters are left as is
   expect_listequal(normalize_unhighlighted_params(list(fill = "red", size = 0.2)),
-                   list(colour = "red", fill = "red", size = 0.2))
+                   list(fill = "red", size = 0.2))
   # color is an alias of colour
   expect_listequal(normalize_unhighlighted_params(list(color = "red")),
-                   list(colour = "red", fill = "red"))
+                   list(colour = "red"))
   # if both colour and color are specified, use colour.
   expect_listequal(normalize_unhighlighted_params(list(colour = "blue", color = "red")),
-                   list(colour = "blue", fill = "blue"))
-  # if both fill and colour are missing, raise error
-  expect_listequal(normalize_unhighlighted_params(list()),
-                   list(colour = ggplot2::alpha("grey", 0.7), fill = ggplot2::alpha("grey", 0.7)))
+                   list(colour = "blue"))
 })

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -16,29 +16,29 @@ test_that("choose_col_for_filter_and_arrange() works", {
                !!expected)
 })
 
-test_that("normalize_unhighlighted_aes() works", {
+test_that("normalize_unhighlighted_params() works", {
   expect_listequal <- function(x, y) {
     expect_equal(!!x[sort(names(x))], !!y[sort(names(y))])
   }
 
   # if fill or colour is missing, use the other for it
-  expect_listequal(normalize_unhighlighted_aes(list(colour = "red")),
+  expect_listequal(normalize_unhighlighted_params(list(colour = "red")),
                    list(colour = "red", fill = "red"))
-  expect_listequal(normalize_unhighlighted_aes(list(fill = "red")),
+  expect_listequal(normalize_unhighlighted_params(list(fill = "red")),
                    list(colour = "red", fill = "red"))
   # if fill and colour is specified, respect both
-  expect_listequal(normalize_unhighlighted_aes(list(colour = "blue", fill = "red")),
+  expect_listequal(normalize_unhighlighted_params(list(colour = "blue", fill = "red")),
                    list(colour = "blue", fill = "red"))
   # other parameters are left as is
-  expect_listequal(normalize_unhighlighted_aes(list(fill = "red", size = 0.2)),
+  expect_listequal(normalize_unhighlighted_params(list(fill = "red", size = 0.2)),
                    list(colour = "red", fill = "red", size = 0.2))
   # color is an alias of colour
-  expect_listequal(normalize_unhighlighted_aes(list(color = "red")),
+  expect_listequal(normalize_unhighlighted_params(list(color = "red")),
                    list(colour = "red", fill = "red"))
   # if both colour and color are specified, use colour.
-  expect_listequal(normalize_unhighlighted_aes(list(colour = "blue", color = "red")),
+  expect_listequal(normalize_unhighlighted_params(list(colour = "blue", color = "red")),
                    list(colour = "blue", fill = "blue"))
   # if both fill and colour are missing, raise error
-  expect_listequal(normalize_unhighlighted_aes(list()),
+  expect_listequal(normalize_unhighlighted_params(list()),
                    list(colour = ggplot2::alpha("grey", 0.7), fill = ggplot2::alpha("grey", 0.7)))
 })


### PR DESCRIPTION
Fix #62 

Replace `unhighlighted_colour` with `unhighlighted_params`.

``` r
library(gghighlight)
#> Loading required package: ggplot2

set.seed(2)
d <- purrr::map_dfr(
  letters,
  ~ data.frame(
    idx = 1:400,
    value = cumsum(runif(400, -1, 1)),
    type = .,
    flag = sample(c(TRUE, FALSE), size = 400, replace = TRUE),
    stringsAsFactors = FALSE
  )
)

ggplot(d) +
  geom_line(aes(idx, value, colour = type), size = 3) +
  gghighlight(max(value) > 19,
              unhighlighted_aes = list(size = 0.4))
#> label_key: type
```

![](https://i.imgur.com/aRk3JAs.png)

<sup>Created on 2018-12-28 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
