### PR TITLE
Use `group` aes if available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
   list of parameters for the unhighlighted layer (e.g. `colour`, `fill`, `shape`,
   and `size`). Accordingly, `unhighlighted_colour` is deprecated (#76).
 
+* If the mapping has `group`, use it as grouping variable, which is consistent
+  with the logic of ggplot2 (#77).
+
 # gghighlight 0.1.0
 
 * Add `gghighlight()`, which replaces the current `gghighlight_line()` and `gghighlight_point()`; these functions are now deprecated.

--- a/tests/testthat/test-gghighlight.R
+++ b/tests/testthat/test-gghighlight.R
@@ -72,6 +72,12 @@ test_that("calculate_group_info() works", {
   # just ignore it.
   expect_equal(calculate_group_info(d, aes(x, y, colour = type, fill = stat(count), alpha = ..count..)),
                list(data = setNames(d[1:3], c("x", "y", "colour")), id = ids, key = aes(colour = type)))
+
+  # if there is group mapping, use it
+  d_with_group <- setNames(d[1:3], c("x", "y", "colour"))
+  d_with_group$group <- d$type == "a"
+  expect_equal(calculate_group_info(d, aes(x, y, group = (type == "a"), colour = type)),
+               list(data = d_with_group, id = c(2, 2, 2, 1, 1, 1, 1), key = aes()))
 })
 
 


### PR DESCRIPTION
Fix #68

Do as ggplot2 does: https://github.com/tidyverse/ggplot2/blob/3e1e6e43af82faf59e37df0724b65c8d829c7b07/R/grouping.r#L11-L28

``` r
library(gghighlight)
#> Loading required package: ggplot2

set.seed(2)
d <- data.frame(x = c(1,2,1,2),
                y = c(1,3,2,4),
                group = c("a", "a", "b", "b"),
                flag = c(1, 1, 0, 1))

ggplot(d, aes(x, y, group = group)) +
  geom_line() +
  gghighlight(sum(flag) > 1)
#> label_key: group
```

![](https://i.imgur.com/XmF2igm.png)

<sup>Created on 2018-12-28 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
