### PR TITLE
Implement keep_scale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,9 @@
 
 * `gghighlight()` now ignores `NA`s in numeric predicates (#86).
 
+* `gghighlight()` gets a new argument `keep_scale` to choose keep the original
+  scale with the shadowed data (#72).
+
 # gghighlight 0.1.0
 
 * Add `gghighlight()`, which replaces the current `gghighlight_line()` and `gghighlight_point()`; these functions are now deprecated.

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -111,15 +111,17 @@ ggplot_add.gg_highlighter <- function(object, plot, object_name) {
     idx_layers[utils::tail(seq_len(n_layers), object$n)] <- TRUE
   }
 
-  # Layers are environments; if we modify an element of it, it keeps the modified value.
-  # So, we need to clone them first.
+  # Layers are environments; if we modify an element in an environment, the
+  # modified value is kept. So, we need to clone them before modifying.
+  # Note that, since the plot data is overwritten later, we need to attach
+  # the data to all layers and then assign back (#31).
   layers_cloned <- purrr::map(plot$layers, clone_layer)
 
-  # data and group IDs are used commonly both in the bleaching and sieving process.
+  # Data and group IDs are used commonly both in the bleaching and sieving process
   purrr::walk(layers_cloned, merge_plot_to_layer,
               plot_data = plot$data, plot_mapping = plot$mapping)
 
-  # since the plot data is overwritten later, we need to attach the data to all layers (#31)
+  # Assign back layers that are not get bleached or sieved
   plot$layers[!idx_layers] <- layers_cloned[!idx_layers]
   layers_cloned <- layers_cloned[idx_layers]
 

--- a/man/gghighlight.Rd
+++ b/man/gghighlight.Rd
@@ -7,7 +7,7 @@
 gghighlight(..., n = NULL, max_highlight = 5L,
   unhighlighted_params = list(), use_group_by = NULL,
   use_direct_label = NULL, label_key = NULL, label_params = list(fill
-  = "white"), unhighlighted_colour = NULL)
+  = "white"), keep_scale = FALSE, unhighlighted_colour = NULL)
 }
 \arguments{
 \item{...}{Expressions to filter data, which is passed to \code{\link[dplyr:filter]{dplyr::filter()}}.}
@@ -25,6 +25,9 @@ gghighlight(..., n = NULL, max_highlight = 5L,
 \item{label_key}{Column name for \code{label} aesthetics.}
 
 \item{label_params}{A list of parameters, which is passed to \code{\link[ggrepel:geom_label_repel]{ggrepel::geom_label_repel()}}.}
+
+\item{keep_scale}{If \code{TRUE}, keep the original data with \code{\link[ggplot2:geom_blank]{ggplot2::geom_blank()}} so that the
+highlighted plot has the same scale with the data.}
 
 \item{unhighlighted_colour}{(Deprecated) Colour for unhighlighted geoms.}
 }

--- a/tests/testthat/test-keep-scale.R
+++ b/tests/testthat/test-keep-scale.R
@@ -1,0 +1,15 @@
+context("test-keep-scale")
+
+test_that("gghighlight(keep_scale = TRUE) keeps the original scale", {
+  # by default, the scale is not kept
+  p1 <- ggplot(data.frame(x = 1:10)) + geom_point(aes(x, x, fill = x)) + gghighlight(x > 5)
+  b1 <- ggplot_build(p1)
+
+  expect_equal(b1$plot$scales$get_scales("fill")$range$range, c(6L, 10L))
+
+  # if keep_scale = TRUE, the original scale is kept
+  p2 <- ggplot(data.frame(x = 1:10)) + geom_point(aes(x, x, fill = x)) + gghighlight(x > 5, keep_scale = TRUE)
+  b2 <- ggplot_build(p2)
+
+  expect_equal(b2$plot$scales$get_scales("fill")$range$range, c(1L, 10L))
+})


### PR DESCRIPTION
Fix #72 

``` r
library(gghighlight)
#> Loading required package: ggplot2
library(patchwork)

set.seed(1)

d <- data.frame(
  idx = c( 1, 1, 1, 2, 2, 2, 3, 3, 3),
  value = c( 1, 2, 3,10,11,12, 9,10,11),
  category = rep(c("a","b","c"), 3),
  cont_var = runif(9),
  stringsAsFactors = FALSE
)

p1 <- ggplot(d, aes(x = idx, y = value, color = cont_var)) +
  geom_point()

p1
```

![](https://i.imgur.com/yfu6et6.png)

``` r

p2 <- p1 + gghighlight(cont_var < 0.5)
p3 <- p1 + gghighlight(cont_var < 0.5, keep_scale = TRUE)

p2 * p3
```

![](https://i.imgur.com/GZgj6hT.png)

<sup>Created on 2019-03-09 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
