### PR TITLE
Add checks about arguments

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -1,0 +1,22 @@
+check_bad_predicates <- function(x) {
+  have_name_idx <- rlang::have_name(x)
+
+  if (any(have_name_idx)) {
+    bad_x <- x[have_name_idx]
+    bad_x_deparsed <- purrr::imap_chr(
+      bad_x,
+      ~ paste(.y, "=", rlang::quo_text(.x))
+    )
+
+    rlang::abort(
+      sprintf("Did you mistyped `==` as `=`?: %s",
+              paste(bad_x_deparsed, collapse = ","))
+    )
+  }
+}
+
+check_bad_label_key <- function(x) {
+  if (!rlang::quo_is_null(x) && !rlang::quo_is_symbol(x)) {
+    rlang::abort("label_key must be a symbol")
+  }
+}

--- a/R/checks.R
+++ b/R/checks.R
@@ -9,7 +9,7 @@ check_bad_predicates <- function(x) {
     )
 
     rlang::abort(
-      sprintf("Did you mistyped `==` as `=`?: %s",
+      sprintf("Did you mistyped some argument name? Or, you meant `==`?: %s",
               paste(bad_x_deparsed, collapse = ","))
     )
   }

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -60,7 +60,13 @@ gghighlight <- function(...,
                         label_params = list(fill = "white"),
                         keep_scale = FALSE,
                         unhighlighted_colour = NULL) {
-
+  
+  predicates <- rlang::enquos(...)
+  label_key <- rlang::enquo(label_key)
+  
+  check_bad_predicates(predicates)
+  check_bad_label_key(label_key)
+  
   # if use_direct_label is NULL, try to use direct labels but ignore failures
   # if use_direct_label is TRUE, use direct labels, otherwise stop()
   # if use_direct_label is FALSE, do not use direct labeys
@@ -80,14 +86,14 @@ gghighlight <- function(...,
 
   structure(
     list(
-      predicates = rlang::enquos(...),
+      predicates = predicates,
       n = n,
       max_highlight = max_highlight,
       unhighlighted_params = unhighlighted_params,
       use_group_by = use_group_by,
       use_direct_label = use_direct_label,
       label_key_must_exist = label_key_must_exist,
-      label_key = rlang::enquo(label_key),
+      label_key = label_key,
       label_params = label_params,
       keep_scale = keep_scale
     ),

--- a/tests/testthat/test-bad-arguments.R
+++ b/tests/testthat/test-bad-arguments.R
@@ -1,0 +1,13 @@
+context("test-bad-arguments")
+
+test_that("mistype of `==` is detected", {
+  expect_error(check_bad_predicates(rlang::quos(a = b)), "Did you mistyped `==` as `=`?: a = b", fixed = TRUE)
+  expect_error(gghighlight(a = b), "Did you mistyped `==` as `=`?: a = b", fixed = TRUE)
+})
+
+test_that("label_key must be a symbol", {
+  expect_error(check_bad_label_key(rlang::quo("foo")), "label_key must be a symbol", fixed = TRUE)
+  expect_error(gghighlight(label_key = "foo"), "label_key must be a symbol", fixed = TRUE)
+  foo <- rlang::quo(foo)
+  expect_error(gghighlight(label_key = !!foo), NA)
+})

--- a/tests/testthat/test-bad-arguments.R
+++ b/tests/testthat/test-bad-arguments.R
@@ -1,8 +1,8 @@
 context("test-bad-arguments")
 
 test_that("mistype of `==` is detected", {
-  expect_error(check_bad_predicates(rlang::quos(a = b)), "Did you mistyped `==` as `=`?: a = b", fixed = TRUE)
-  expect_error(gghighlight(a = b), "Did you mistyped `==` as `=`?: a = b", fixed = TRUE)
+  expect_error(check_bad_predicates(rlang::quos(a = b)), "Did you mistyped some argument name? Or, you meant `==`?: a = b", fixed = TRUE)
+  expect_error(gghighlight(a = b), "Did you mistyped some argument name? Or, you meant `==`?: a = b", fixed = TRUE)
 })
 
 test_that("label_key must be a symbol", {


### PR DESCRIPTION
Fix #92 

``` r
library(gapminder)
library(gganimate)
#> Loading required package: ggplot2
library(gghighlight)

ggplot(gapminder, aes(gdpPercap, lifeExp, size = pop, colour = country)) +
  geom_point(alpha = 0.7, show.legend = FALSE) +
  gghighlight(use_direct_labels = FALSE) +
  scale_colour_manual(values = country_colors) +
  scale_size(range = c(2, 12)) +
  scale_x_log10() +
  facet_wrap(~continent) +
  # Here comes the gganimate specific bits
  labs(title = 'Year: {frame_time}', x = 'GDP per capita', y = 'life expectancy') +
  transition_time(year) +
  ease_aes('linear')
#> Error: Did you mistyped some argument name? Or, you meant `==`?: use_direct_labels = FALSE
```

<sup>Created on 2019-03-09 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
