### PR TITLE
Add option to control whether to ignore facets or not

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,8 +15,11 @@
 
 * `gghighlight()` now ignores `NA`s in numeric predicates (#86).
 
-* `gghighlight()` gets a new argument `keep_scale` to choose keep the original
-  scale with the shadowed data (#72).
+* `gghighlight()` gets a new argument `keep_scale` to choose whether to keep the
+  original scale with the shadowed data (#72).
+
+* `gghighlight()` gets an experimental argument `use_facet_vars` to choose whether
+  to calculate highlighting per facet (#14).
 
 # gghighlight 0.1.0
 

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -24,7 +24,8 @@
 #'   If `TRUE`, keep the original data with [ggplot2::geom_blank()] so that the
 #'   highlighted plot has the same scale with the data.
 #' @param use_facet_vars
-#'   If `TRUE`, calculate the predicates per facet.
+#'   (Experimental) If `TRUE`, include the facet variables to calculate the
+#'   grouping; in other words, highlighting is done on each facet individually.
 #' @param unhighlighted_colour
 #'   (Deprecated) Colour for unhighlighted geoms.
 #'

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -23,6 +23,8 @@
 #' @param keep_scale
 #'   If `TRUE`, keep the original data with [ggplot2::geom_blank()] so that the
 #'   highlighted plot has the same scale with the data.
+#' @param use_facet_vars
+#'   If `TRUE`, calculate the predicates per facet.
 #' @param unhighlighted_colour
 #'   (Deprecated) Colour for unhighlighted geoms.
 #'
@@ -59,6 +61,7 @@ gghighlight <- function(...,
                         label_key = NULL,
                         label_params = list(fill = "white"),
                         keep_scale = FALSE,
+                        use_facet_vars = FALSE,
                         unhighlighted_colour = NULL) {
   
   predicates <- rlang::enquos(...)
@@ -95,7 +98,8 @@ gghighlight <- function(...,
       label_key_must_exist = label_key_must_exist,
       label_key = label_key,
       label_params = label_params,
-      keep_scale = keep_scale
+      keep_scale = keep_scale,
+      use_facet_vars = use_facet_vars
     ),
     class = "gg_highlighter"
   )
@@ -136,7 +140,11 @@ ggplot_add.gg_highlighter <- function(object, plot, object_name) {
   plot$layers[!idx_layers] <- layers_cloned[!idx_layers]
   layers_cloned <- layers_cloned[idx_layers]
 
-  group_infos <- purrr::map(layers_cloned, ~ calculate_group_info(.$data, .$mapping))
+  facet_vars <- if (object$use_facet_vars) get_facet_vars(plot$facet) else NULL
+  group_infos <- purrr::map(
+    layers_cloned,
+    ~ calculate_group_info(.$data, .$mapping, extra_vars = facet_vars)
+  )
 
   # Clone layers again seperately (layers_cloned will be used later for keeping 
   # the original scale)
@@ -148,7 +156,8 @@ ggplot_add.gg_highlighter <- function(object, plot, object_name) {
     layers_bleached,
     group_infos,
     bleach_layer,
-    unhighlighted_params = object$unhighlighted_params
+    unhighlighted_params = object$unhighlighted_params,
+    use_facet_vars = object$use_facet_vars
   )
 
   # Sieve the upper layer.
@@ -235,7 +244,7 @@ clone_layer <- function(layer) {
 
 clone_position <- clone_layer
 
-calculate_group_info <- function(data, mapping) {
+calculate_group_info <- function(data, mapping, extra_vars = NULL) {
   mapping <- purrr::compact(mapping)
   # the calculation may be possible only in the ggplot2 context (e.g. stat()).
   # So, wrap it with tryCatch() and remove the failed results, which can be
@@ -253,23 +262,38 @@ calculate_group_info <- function(data, mapping) {
     group_cols <- names(which(idx_discrete))
   }
 
+  # for group key, use symbols only, and don't include extra_vars
+  group_keys <- purrr::keep(mapping[group_cols], rlang::quo_is_symbol)
+  
+  # if extra variables (e.g. facet specs) are specified, use them.
+  if (!is.null(extra_vars)) {
+    if (!rlang::is_quosures(extra_vars) || !all(rlang::have_name(extra_vars))) {
+      rlang::abort("extra_vars must be a named quosures object.")
+    }
+    extra_data <- dplyr::transmute(data, !!!extra_vars)
+  } else {
+    extra_data <- NULL
+  }
+
   # no group
   if (length(group_cols) == 0) {
     return(NULL)
   }
 
+  # calculate group IDs with extra_vars
+  group_ids <- dplyr::group_indices(
+    dplyr::bind_cols(data_evaluated, extra_data),
+    !!!rlang::syms(c(group_cols, names(extra_data)))
+  )
+
   list(
     data = data_evaluated,
-    id = dplyr::group_indices(
-      data_evaluated,  # group_indices() won't work with grouped_df.
-      !!!rlang::syms(group_cols)
-    ),
-    # for group key, use symbols only
-    key = purrr::keep(mapping[group_cols], rlang::quo_is_symbol)
+    id = group_ids,
+    key = group_keys
   )
 }
 
-bleach_layer <- function(layer, group_info, unhighlighted_params) {
+bleach_layer <- function(layer, group_info, unhighlighted_params, use_facet_vars = FALSE) {
   # `colour` and `fill` are special in that they needs to be specified even when
   # it is not included in unhighlighted_params. But, if the default_aes is NA,
   # respect it (e.g. geom_bar()'s default colour is NA).
@@ -288,23 +312,34 @@ bleach_layer <- function(layer, group_info, unhighlighted_params) {
   # remove colour and fill from mapping
   layer$mapping[c("colour", "fill")] <- list(NULL)
 
-  # FIXME: Isn't this always necessary?
-  if (!is.null(group_info$key)) {
-    # In order to prevent the bleached layer from being facetted, we need to rename
-    # columns of group keys to improbable names. But, what happens when the group
-    # column disappears? Other calculations that uses the column fail. So, we need
-    # to use the pre-evaluated values and rename everything to improbable name.
-    layer$data <- group_info$data
-    secret_prefix <- rlang::expr_text(VERY_SECRET_COLUMN_NAME)
-    mapping_names <- names(layer$data)
-    secret_names <- paste0(secret_prefix, seq_along(mapping_names))
-    secret_quos <- rlang::quos(!!!rlang::syms(secret_names))
-    layer$data <- dplyr::rename(layer$data, !!!stats::setNames(mapping_names, secret_names))
-    layer$mapping <- utils::modifyList(layer$mapping, stats::setNames(secret_quos, mapping_names))
+  # FIXME: can this be removed?
+  if (is.null(group_info$key)) {
+    return(layer)
+  }
+  
+  # In order to prevent the bleached layer from being facetted, we need to rename
+  # columns of group keys to improbable names. But, what happens when the group
+  # column disappears? Other calculations that uses the column fail. So, we need
+  # to use the pre-evaluated values and rename everything to improbable name.
+  bleached_data <- group_info$data
+  secret_prefix <- rlang::expr_text(VERY_SECRET_COLUMN_NAME)
+  mapping_names <- names(bleached_data)
+  secret_names <- paste0(secret_prefix, seq_along(mapping_names))
+  secret_quos <- rlang::quos(!!!rlang::syms(secret_names))
+  bleached_data <- dplyr::rename(bleached_data, !!!stats::setNames(mapping_names, secret_names))
+  layer$mapping <- utils::modifyList(layer$mapping, stats::setNames(secret_quos, mapping_names))
+  
+  secret_name_group <- paste0(secret_prefix, "group")
+  bleached_data[secret_name_group] <- factor(group_info$id)
+  layer$mapping$group <- rlang::quo(!!rlang::sym(secret_name_group))
 
-    secret_name_group <- paste0(secret_prefix, "group")
-    layer$data[secret_name_group] <- factor(group_info$id)
-    layer$mapping$group <- rlang::quo(!!rlang::sym(secret_name_group))
+  # FIXME:
+  # Contradictorily to the comment above, we need the original data to let the
+  # layer be facetted. Probably, we can make here more efficient...
+  if (use_facet_vars) {
+    layer$data <- dplyr::bind_cols(bleached_data, layer$data)
+  } else {
+    layer$data <- bleached_data
   }
 
   layer

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -276,11 +276,11 @@ calculate_group_info <- function(data, mapping, extra_vars = NULL) {
   }
 
   # no group
-  if (length(group_cols) == 0) {
+  if (length(group_cols) == 0 && rlang::is_empty(extra_data)) {
     return(NULL)
   }
 
-  # calculate group IDs with extra_vars
+  # calculate group IDs with extra_data
   group_ids <- dplyr::group_indices(
     dplyr::bind_cols(data_evaluated, extra_data),
     !!!rlang::syms(c(group_cols, names(extra_data)))

--- a/R/util.R
+++ b/R/util.R
@@ -7,3 +7,12 @@
     lhs
   }
 }
+
+get_facet_vars <- function(facet) {
+  switch(class(facet)[1],
+    "FacetGrid" = rlang::as_quosures(c(facet$params$rows, facet$params$cols)),
+    "FacetWrap" = rlang::as_quosures(facet$params$facets),
+    "FacetNull" = NULL,
+    rlang::abort("Unknown facet class")
+  )
+}

--- a/man/gghighlight.Rd
+++ b/man/gghighlight.Rd
@@ -30,7 +30,8 @@ gghighlight(..., n = NULL, max_highlight = 5L,
 \item{keep_scale}{If \code{TRUE}, keep the original data with \code{\link[ggplot2:geom_blank]{ggplot2::geom_blank()}} so that the
 highlighted plot has the same scale with the data.}
 
-\item{use_facet_vars}{If \code{TRUE}, calculate the predicates per facet.}
+\item{use_facet_vars}{(Experimental) If \code{TRUE}, include the facet variables to calculate the
+grouping; in other words, highlighting is done on each facet individually.}
 
 \item{unhighlighted_colour}{(Deprecated) Colour for unhighlighted geoms.}
 }

--- a/man/gghighlight.Rd
+++ b/man/gghighlight.Rd
@@ -7,7 +7,8 @@
 gghighlight(..., n = NULL, max_highlight = 5L,
   unhighlighted_params = list(), use_group_by = NULL,
   use_direct_label = NULL, label_key = NULL, label_params = list(fill
-  = "white"), keep_scale = FALSE, unhighlighted_colour = NULL)
+  = "white"), keep_scale = FALSE, use_facet_vars = FALSE,
+  unhighlighted_colour = NULL)
 }
 \arguments{
 \item{...}{Expressions to filter data, which is passed to \code{\link[dplyr:filter]{dplyr::filter()}}.}
@@ -28,6 +29,8 @@ gghighlight(..., n = NULL, max_highlight = 5L,
 
 \item{keep_scale}{If \code{TRUE}, keep the original data with \code{\link[ggplot2:geom_blank]{ggplot2::geom_blank()}} so that the
 highlighted plot has the same scale with the data.}
+
+\item{use_facet_vars}{If \code{TRUE}, calculate the predicates per facet.}
 
 \item{unhighlighted_colour}{(Deprecated) Colour for unhighlighted geoms.}
 }

--- a/tests/testthat/test-bleach.R
+++ b/tests/testthat/test-bleach.R
@@ -13,9 +13,9 @@ d <- tibble::tribble(
    3,  3,   "c",     10
 )
 
-d_ <- setNames(d[1:3], c("x", "y", "colour"))
+d_expect <- setNames(d[1:3], c("x", "y", "colour"))
 ids <- c(1, 1, 1, 2, 2, 3, 3)
-g_info <- list(data = d_, id = ids, key = aes(colour = type))
+g_info <- list(data = d_expect, id = ids, key = aes(colour = type))
 
 d_bleached <- d[1:3]
 d_bleached$ids <- factor(ids)
@@ -92,5 +92,12 @@ test_that("bleach_layer() works for NULL default aes", {
             colour = grey07,
             fill = grey07)[[1]]
   )
+
+})
+
+test_that("bleach_layer(use_facet_vars = TRUE) adds the original data", {
+  # If colour is specified, colour is used as the group key.
+  expect_equal_layer(bleach_layer(geom_line(aes(colour = type), d), g_info, list(), use_facet_vars = TRUE),
+                     geom_line(aes_bleached, dplyr::bind_cols(d_bleached, d), colour = grey07))
 
 })

--- a/tests/testthat/test-calculate-group.R
+++ b/tests/testthat/test-calculate-group.R
@@ -1,42 +1,71 @@
 context("test-calculate-group")
 
-d <- tibble::tribble(
-  ~x, ~y, ~type, ~value,
-   1,  2,   "a",      0,
-   2,  3,   "a",      1,
-   3,  4,   "a",      0,
-   1,  3,   "b",      1,
-   2,  2,   "b",      5,
-   1,  4,   "c",     10,
-   3,  3,   "c",     10
-)
-
-d_ <- setNames(d[1:3], c("x", "y", "colour"))
-ids <- c(1, 1, 1, 2, 2, 3, 3)
-
-# tests -------------------------------------------------------------------
-
 
 test_that("calculate_group_info() works", {
+  d <- tibble::tribble(
+    ~x, ~y, ~type, ~value,
+     1,  2,   "a",      0,
+     2,  3,   "a",      1,
+     3,  4,   "a",      0,
+     1,  3,   "b",      1,
+     2,  2,   "b",      5,
+     1,  4,   "c",     10,
+     3,  3,   "c",     10
+  )
+  
+  d_expect <- setNames(d[1:3], c("x", "y", "colour"))
+  ids <- c(1, 1, 1, 2, 2, 3, 3)
+
   expect_equal(calculate_group_info(d, aes(x, y, colour = type)),
-               list(data = setNames(d[1:3], c("x", "y", "colour")), id = ids, key = aes(colour = type)))
+               list(data = d_expect, id = ids, key = aes(colour = type)))
   # if there's no discrete key, return NULL
   expect_equal(calculate_group_info(d, aes(x, y, colour = x)),
                NULL)
   # if some aes is the call, caluculated result is used. But it's not used for group keys.
-  d2 <- setNames(d[1:3], c("x", "y", "colour"))
-  d2$colour <- factor(d2$colour)
+  d_expect_factor <- d_expect
+  d_expect_factor$colour <- factor(d_expect_factor$colour)
   expect_equal(calculate_group_info(d, aes(x, y, colour = factor(type))),
-               list(data = d2, id = ids, key = aes()))
+               list(data = d_expect_factor, id = ids, key = aes()))
 
   # if aes contains expressions that cannot be evaluated outside ggplot2 (e.g. stat(count)),
   # just ignore it.
   expect_equal(calculate_group_info(d, aes(x, y, colour = type, fill = stat(count), alpha = ..count..)),
-               list(data = setNames(d[1:3], c("x", "y", "colour")), id = ids, key = aes(colour = type)))
+               list(data = d_expect, id = ids, key = aes(colour = type)))
 
   # if there is group mapping, use it
-  d_with_group <- setNames(d[1:3], c("x", "y", "colour"))
-  d_with_group$group <- d$type == "a"
+  d_expect_group <- d_expect
+  d_expect_group$group <- d$type == "a"
   expect_equal(calculate_group_info(d, aes(x, y, group = (type == "a"), colour = type)),
-               list(data = d_with_group, id = c(2, 2, 2, 1, 1, 1, 1), key = aes()))
+               list(data = d_expect_group, id = c(2, 2, 2, 1, 1, 1, 1), key = aes()))
+})
+
+
+test_that("calculate_group_info() works with facets", {
+  d <- tibble::tribble(
+    ~idx, ~value, ~cat1, ~cat2,
+       1,     10,   "a", "1-2",
+       2,     11,   "a", "1-2",
+       3,     12,   "a", "3-4",
+       4,     13,   "a", "3-4",
+       1,      4,   "b", "1-2",
+       2,      8,   "b", "1-2",
+       3,     16,   "b", "3-4",
+       4,     32,   "b", "3-4"
+  )
+
+  d_expect <- setNames(d[1:3], c("x", "y", "colour"))
+  ids <- c(1, 1, 2, 2, 3, 3, 4, 4)
+  
+  expect_equal(calculate_group_info(d, aes(idx, value, colour = cat1), extra_vars = rlang::quos(cat2 = cat2)),
+               list(data = d_expect, id = ids, key = aes(colour = cat1)))
+  
+  # Even if there's no discrete key, return a group info if there's an extra_vars
+  expect_equal(calculate_group_info(d, aes(idx, value), extra_vars = rlang::quos(cat2 = cat2)),
+               list(data = d_expect[, c("x", "y")], id = ids[c(1:4, 1:4)], key = aes()))
+  
+  # If extra_vars is empty, it doesn't affect on grouping
+  expect_equal(calculate_group_info(d, aes(idx, value), extra_vars = rlang::quos()),
+               NULL)
+  expect_equal(calculate_group_info(d, aes(idx, value, colour = cat1), extra_vars = rlang::quos()),
+               list(data = d_expect, id = rep(1:2, each = 4), key = aes(colour = cat1)))
 })

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -49,3 +49,16 @@ test_that("calculate_ungrouped() and calculate_grouped() don't drop data.frames"
                d[6:10, , drop = FALSE])
 
 })
+
+test_that("get_facet_vars() extract facet specs", {
+  p <- ggplot()
+  v <- rlang::quos(A = a, B = b)
+  
+  expect_identical(get_facet_vars(p$facet), NULL)
+  expect_identical(get_facet_vars((p + facet_wrap(v))$facet), v)
+  expect_identical(get_facet_vars((p + facet_grid(v))$facet), v)
+  expect_identical(get_facet_vars((p + facet_grid(v[1], v[2]))$facet), v)
+
+  class(p$facet) <- c("FacetUnknown", class(p$facet))
+  expect_error(get_facet_vars(p$facet))
+})


### PR DESCRIPTION
Fix #14 

Note that this feels a hacky way, and I'm not sure if this is a reliable approach.

To work with facets, gghighlight needs to do two things:

1. Consider facet specs when calculating the group IDs.
2. Include the original data in the bleached layer so that it is facetted.

Especially, 1. is tricky; we need evaluate facet specs for IDs, but the evaluated data itself should not be included in the data (because I'm not sure tweaking the quosures of the facet spec is safe).

``` r
library(gghighlight)
#> Loading required package: ggplot2
library(patchwork)

d <- data.frame(
  idx =   c(1, 2, 3, 4, 1, 2, 3, 4),
  value = c(10, 11, 12, 13, 4, 8, 16, 32),
  cat1 =  rep(c("a", "b"), each = 4),
  cat2 =  rep(rep(c("1-2", "3-4"), each = 2), 2),
  stringsAsFactors = FALSE
)

p <- ggplot(d, aes(idx, value, colour = cat1)) +
  geom_line() +
  facet_wrap(vars(cat2))

p1 <- p +
  gghighlight(max(value) > 10) +
  ggtitle("(normal)")
#> label_key: cat1

p2 <- p +
  gghighlight(max(value) > 10, use_facet_vars = TRUE) +
  ggtitle("use_facet_vars = TRUE")
#> label_key: cat1

p1 / p2
```

![](https://i.imgur.com/nakeBwt.png)

<sup>Created on 2019-03-17 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
