### PR TITLE
Remove context()

### DIFF
--- a/tests/testthat/test-bad-arguments.R
+++ b/tests/testthat/test-bad-arguments.R
@@ -1,5 +1,3 @@
-context("test-bad-arguments")
-
 test_that("mistype of `==` is detected", {
   expect <- "Did you mistype some argument name? Or, did you mean `==`?: a = b"
   expect_error(check_bad_predicates(quos(a = b)), expect, fixed = TRUE)

--- a/tests/testthat/test-bleach.R
+++ b/tests/testthat/test-bleach.R
@@ -1,5 +1,3 @@
-context("test-bleach")
-
 grey07 <- scales::alpha("grey", 0.7)
 
 d <- tibble::tribble(

--- a/tests/testthat/test-calculate-group.R
+++ b/tests/testthat/test-calculate-group.R
@@ -1,6 +1,3 @@
-context("test-calculate-group")
-
-
 test_that("calculate_group_info() works", {
   d <- tibble::tribble(
     ~x, ~y, ~type, ~value,

--- a/tests/testthat/test-gghighlight.R
+++ b/tests/testthat/test-gghighlight.R
@@ -1,5 +1,3 @@
-context("test-gghighlight.R")
-
 grey07 <- scales::alpha("grey", 0.7)
 
 d <- tibble::tribble(

--- a/tests/testthat/test-gghighlight_old_point.R
+++ b/tests/testthat/test-gghighlight_old_point.R
@@ -1,5 +1,3 @@
-context("gghighlight_point")
-
 d <- data.frame(
   x     = c( 1, 1, 1, 2, 2, 2, 3, 3, 3),
   y     = c( 1, 2, 3, 1, 2, 3, 1, 2, 3),

--- a/tests/testthat/test-gghighligt_old_line.R
+++ b/tests/testthat/test-gghighligt_old_line.R
@@ -1,5 +1,3 @@
-context("gghighligt_line")
-
 d <- data.frame(
   idx   = c( 1, 1, 1, 2, 2, 2, 3, 3, 3),
   value = c( 1, 2, 3,10,11,12, 9,10,11),

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -1,5 +1,3 @@
-context("test-internals.R")
-
 test_that("choose_col_for_filter_and_arrange() works", {
   d1 <- tibble::tibble(x = 1,
                        y = "a",

--- a/tests/testthat/test-keep-scale.R
+++ b/tests/testthat/test-keep-scale.R
@@ -1,5 +1,3 @@
-context("test-keep-scale")
-
 test_that("gghighlight(keep_scales = TRUE) keeps the original scale", {
   # by default, the scale is not kept
   p1 <- ggplot(data.frame(x = 1:10)) + geom_point(aes(x, x, fill = x)) + gghighlight(x > 5)

--- a/tests/testthat/test-label.R
+++ b/tests/testthat/test-label.R
@@ -1,5 +1,3 @@
-context("test-label.R")
-
 type_chr <- c("a", "a", "b", "b")
 d <- data.frame(x = 1:4, y = 1:4, type = type_chr, type2 = type_chr, stringsAsFactors = FALSE)
 d2 <- data.frame(x = 1, y = 2, type = "a")

--- a/tests/testthat/test-merge.R
+++ b/tests/testthat/test-merge.R
@@ -1,5 +1,3 @@
-context("test-merge")
-
 d <- tibble::tribble(
   ~x, ~y, ~type, ~value,
    1,  2,   "a",      0,

--- a/tests/testthat/test-sieve.R
+++ b/tests/testthat/test-sieve.R
@@ -1,5 +1,3 @@
-context("test-sieve")
-
 grey07 <- scales::alpha("grey", 0.7)
 
 d <- tibble::tribble(

--- a/tests/testthat/test-vdiffr.R
+++ b/tests/testthat/test-vdiffr.R
@@ -1,5 +1,3 @@
-context("visual tests")
-
 test_that("gghighlight() highlights correctly", {
   vdiffr::expect_doppelganger(
     "simple bar chart",


### PR DESCRIPTION
The use of `context()` has been discouraged since testthat 2.1.0.

> ProgressReporter, the default reporter, now:
>
>    Automatically generates a context from the file name. We no longer recommend the use of `context()` and instead encourage you to delete it, allowing the context to be autogenerated from the file name.
(https://testthat.r-lib.org/news/index.html#reporters)