### PR TITLE
Do not overwrite seed

### DIFF
--- a/R/label.R
+++ b/R/label.R
@@ -99,13 +99,14 @@ generate_label_for_point <- function(layer, label_key, label_params) {
   mapping <- layer$mapping
   mapping$label <- label_key
 
-  position <- clone_position(layer$position)
-  if (inherits(position, "PositionJitter") && is.null(position$seed)) {
+  if (inherits(layer$position, "PositionJitter") && is.null(layer$position$seed)) {
     # FIXME when this is fixed on upstream: https://github.com/tidyverse/ggplot2/issues/2507
+    position <- clone_position(layer$position)
     position$seed <- sample.int(.Machine$integer.max, 1L)
+    layer$position <- position
   }
-  layer$position <- position
-  label_params$position <- position
+
+  label_params$position <- layer$position
 
   call_ggrepel_with_params(mapping, layer$data, label_params)
 }

--- a/R/label.R
+++ b/R/label.R
@@ -99,12 +99,12 @@ generate_label_for_point <- function(layer, label_key, label_params) {
   mapping <- layer$mapping
   mapping$label <- label_key
 
-  if (inherits(layer$position, "PositionJitter") && is.null(layer$position$seed)) {
-    # FIXME when this is fixed on upstream: https://github.com/tidyverse/ggplot2/issues/2507
-    layer$position$seed <- sample.int(.Machine$integer.max, 1L)
-  }
-
   position <- clone_position(layer$position)
+  if (inherits(position, "PositionJitter") && is.null(position$seed)) {
+    # FIXME when this is fixed on upstream: https://github.com/tidyverse/ggplot2/issues/2507
+    position$seed <- sample.int(.Machine$integer.max, 1L)
+  }
+  layer$position <- position
   label_params$position <- position
 
   call_ggrepel_with_params(mapping, layer$data, label_params)

--- a/tests/testthat/test-label.R
+++ b/tests/testthat/test-label.R
@@ -90,6 +90,9 @@ test_that("generate_labelled_layer() geenrates a layer for label.", {
   l_label <- generate_labelled_layer(list(l_jitter), list(g_info), type2_quo, list(fill = "white"))
   expect_true(!is.null(l_jitter$position$seed))
   expect_equal(l_label$position$seed, l_jitter$position$seed)
+
+  # Do not modify the original env
+  expect_true(is.null(ggplot2::PositionJitter$seed))
 })
 
 test_that("call_ggrepel_with_params() generates a geom_label_repel()", {


### PR DESCRIPTION
The current code modifies the original `PositionJitter`, which is dangerous...

https://github.com/yutannihilation/gghighlight/blob/c544cc1b52b1e8bf21874db4c6c0e17773682bba/R/label.R#L104

Clone the position before injecting the seed.