### PR TITLE
Handle descrete scale on calculating label positions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
     ggplot2 (>= 3.0.0),
     R (>= 3.2.0)
 Imports:
-    dplyr (> 0.7.0),
+    dplyr (>= 1.0.0),
     ggrepel,
     lifecycle,
     purrr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gghighlight (development version)
 
+* `gghighlight()` now can add labels on discrete scales (#160).
+
 # gghighlight 0.3.0
 
 ## Breaking changes

--- a/R/label.R
+++ b/R/label.R
@@ -89,8 +89,8 @@ generate_label_for_line <- function(layer, label_key, label_params, max_labels) 
     inform("Too many data series, skip labeling")
     return(list())
   }
-  
-  rightmost_points <- dplyr::filter(data, !!x_key == max(!!x_key))
+
+  rightmost_points <- dplyr::slice_max(data, !!x_key)
   # max value can appear multiple times, so ensure only one row per group
   rightmost_points <- dplyr::slice(rightmost_points, 1)
 
@@ -105,7 +105,7 @@ generate_label_for_point <- function(layer, label_key, label_params, max_labels)
     inform("Too many data points, skip labeling")
     return(list())
   }
-  
+
   mapping <- layer$mapping
   mapping$label <- label_key
 


### PR DESCRIPTION
Fix #160

Currently, gghighlight uses `max()` to calculate the right-most position of a data series. dplyr 1.0.0 now has `slice_max()` function, which can be used for factors and characters. So, let's switch to it.