### PR TITLE
Keep colors of unhighlighted

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * `gghighlight()` now accepts `n()` so that you can highlight based on the
   number of rows within each group (#154).
+* `gghighlight()` now preserves `colour` or `fill` when explicit `NULL` is
+  specified on `unhighlighted_params` (i.e. `unhighlighted_params = list(colour = NULL)`)
+  (#152).
 
 # gghighlight 0.3.1
 

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -314,8 +314,20 @@ bleach_layer <- function(layer, group_info, unhighlighted_params, calculate_per_
   # it is not included in unhighlighted_params. But, if the default_aes is NA,
   # respect it (e.g. geom_bar()'s default colour is NA).
   # Note that this depends on the mapping, so this needs to be done before modifying the mapping.
-  unhighlighted_params$colour <- unhighlighted_params$colour %||% get_default_aes_param("colour", layer$geom, layer$mapping)
-  unhighlighted_params$fill <- unhighlighted_params$fill %||% get_default_aes_param("fill", layer$geom, layer$mapping)
+  for (nm in c("colour", "fill")) {
+    if (is.null(unhighlighted_params[[nm]])) {
+      # if the aesthetic name is explicit NULL, then do nothing
+      if (has_name(unhighlighted_params, nm)) {
+        next
+      }
+      # if the aesthetic name is not specified, fill it with the default
+      unhighlighted_params[[nm]] <- get_default_aes_param(nm, layer$geom, layer$mapping)
+    }
+
+    # FIXME: Is this necessary while aes_params will override these mappings?
+    # remove colour and fill from mapping
+    layer$mapping[nm] <- list(NULL)
+  }
 
   # c.f. https://github.com/tidyverse/ggplot2/blob/e9d4e5dd599b9f058cbe9230a6517f85f3587567/R/layer.r#L107-L108
   aes_params_bleached <- unhighlighted_params[names(unhighlighted_params) %in% layer$geom$aesthetics()]
@@ -323,10 +335,6 @@ bleach_layer <- function(layer, group_info, unhighlighted_params, calculate_per_
 
   layer$aes_params <- utils::modifyList(layer$aes_params, aes_params_bleached)
   layer$geom_params <- utils::modifyList(layer$geom_params, geom_params_bleached)
-
-  # FIXME: Is this necessary while aes_params will override these mappings?
-  # remove colour and fill from mapping
-  layer$mapping[c("colour", "fill")] <- list(NULL)
 
   # FIXME: can this be removed?
   if (is.null(group_info$key)) {

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -14,7 +14,8 @@
 #' @param max_highlight
 #'   Max number of series to highlight.
 #' @param unhighlighted_params
-#'   Aesthetics (e.g. colour, fill, and size) for unhighlighted geoms.
+#'   Aesthetics (e.g. colour, fill, and size) for unhighlighted geoms. Specifying
+#'   `colour = NULL` or `fill = NULL` will preserve the original colour.
 #' @param use_group_by
 #'   If `TRUE`, use [dplyr::group_by()] to evaluate `predicate`.
 #' @param use_direct_label

--- a/man/gghighlight.Rd
+++ b/man/gghighlight.Rd
@@ -25,7 +25,8 @@ gghighlight(
 
 \item{max_highlight}{Max number of series to highlight.}
 
-\item{unhighlighted_params}{Aesthetics (e.g. colour, fill, and size) for unhighlighted geoms.}
+\item{unhighlighted_params}{Aesthetics (e.g. colour, fill, and size) for unhighlighted geoms. Specifying
+\code{colour = NULL} or \code{fill = NULL} will preserve the original colour.}
 
 \item{use_group_by}{If \code{TRUE}, use \code{\link[dplyr:group_by]{dplyr::group_by()}} to evaluate \code{predicate}.}
 

--- a/tests/testthat/test-bleach.R
+++ b/tests/testthat/test-bleach.R
@@ -75,6 +75,13 @@ test_that("bleach_layer() works", {
   expect_equal_layer(bleach_layer(geom_col(aes(colour = type, fill = type), d), g_info,
                                   list(colour = grey09, fill = grey07, width = 0.5)),
                      geom_col(aes_bleached, d_bleached, colour = grey09, fill = grey07, width = 0.5))
+
+  # unhighlighted params (#152)
+  aes_bleached_wo_fill <- aes_bleached
+  aes_bleached_wo_fill$fill <- aes(fill = type)$fill
+  expect_equal_layer(bleach_layer(geom_col(aes(colour = type, fill = type), d), g_info,
+                                  list(colour = grey09, fill = NULL, width = 0.5)),
+                     geom_col(aes_bleached_wo_fill, d_bleached, colour = grey09, width = 0.5))
 })
 
 test_that("bleach_layer() works for NULL default aes", {

--- a/vignettes/gghighlight.Rmd
+++ b/vignettes/gghighlight.Rmd
@@ -230,11 +230,11 @@ ggplot(d) +
 You can also specify `NULL` to `fill` or `colour` to preserve the original color.
 
 ```{r gghighlight-params-null}
-ggplot(d2, aes(idx, value, colour = flag, fill = value)) +
-  geom_point(size = 6, stroke = 1, shape = 21) +
-  gghighlight(value > 0, use_direct_label = FALSE,
-              # preserve colour
-              unhighlighted_params = list(colour = NULL))
+ggplot(d) +
+  geom_line(aes(idx, value, colour = type)) +
+  gghighlight(max(value) > 19,
+              # preserve colour and modify alpha instead
+              unhighlighted_params = list(colour = NULL, alpha = 0.3))
 ```
 
 ### `keep_scales`

--- a/vignettes/gghighlight.Rmd
+++ b/vignettes/gghighlight.Rmd
@@ -227,6 +227,16 @@ ggplot(d) +
               unhighlighted_params = list(size = 1, colour = alpha("pink", 0.4)))
 ```
 
+You can also specify `NULL` to `fill` or `colour` to preserve the original color.
+
+```{r gghighlight-params-null}
+ggplot(d2, aes(idx, value, colour = flag, fill = value)) +
+  geom_point(size = 6, stroke = 1, shape = 21) +
+  gghighlight(value > 0, use_direct_label = FALSE,
+              # preserve colour
+              unhighlighted_params = list(colour = NULL))
+```
+
 ### `keep_scales`
 
 If you want to keep the original scales, set `keep_scales` to `TRUE`.


### PR DESCRIPTION
Fix #152, Fix #164 

``` r
devtools::load_all("~/repo/gghighlight/")
#> ℹ Loading gghighlight
#> Loading required package: ggplot2

set.seed(2)
d <- purrr::map_dfr(
  letters,
  ~ data.frame(
    idx = 1:400,
    value = cumsum(runif(400, -1, 1)),
    type = .,
    flag = sample(c(TRUE, FALSE), size = 400, replace = TRUE),
    stringsAsFactors = FALSE
  )
)

# Usual one
ggplot(d) +
  geom_line(aes(idx, value, colour = type)) +
  gghighlight(max(value) > 19)
#> label_key: type
```

![](https://i.imgur.com/xoYS2kB.png)

``` r
# Preserve the colour and modify alpha instead
ggplot(d) +
  geom_line(aes(idx, value, colour = type)) +
  gghighlight(max(value) > 19,
              unhighlighted_params = list(colour = NULL, alpha = 0.3))
#> label_key: type
```

![](https://i.imgur.com/V5fz10h.png)

<sup>Created on 2021-06-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>