### PR TITLE
Prevent the prior calculated results from being misused

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 * `gghighlight()` now preserves `colour` or `fill` when explicit `NULL` is
   specified on `unhighlighted_params` (i.e. `unhighlighted_params = list(colour = NULL)`)
   (#152).
+* Fix a longstanding bug of wrong calculation when the data has the same name of
+  columns as aesthetics, e.g. `x` (#168).
 
 # gghighlight 0.3.1
 

--- a/R/util.R
+++ b/R/util.R
@@ -16,3 +16,13 @@ get_facet_vars <- function(facet) {
     abort("Unknown facet class")
   )
 }
+
+# Wrap expressions in dplyr::transmute() to prevent from the prior calculated
+# results are referred.
+quasi_parallel <- function(..., ..nrow) {
+  l <- dots_list(..., .named = TRUE)
+  if (is_empty(l)) {
+    return(NULL)
+  }
+  tibble::new_tibble(l, nrow = ..nrow)
+}


### PR DESCRIPTION
Fix #143

In the following `dplyr::transmute()`, a column name `x` in `y = x` refers to the previously generated column `x`, which is actually `other_col`. 

``` r
data <- data.frame(x = 1, y = 2, other_col = 3)

dplyr::transmute(data,
  x = other_col,
  y = x
)
```

To ensure the variable refers to the original column, the expressions needs to be wrapped by data.frame and let it get auto-unspliced.


``` r
library(patchwork)
devtools::load_all("~/repo/gghighlight/")
#> ℹ Loading gghighlight
#> Loading required package: ggplot2

set.seed(22)
df <- tibble::tibble(
  week = rep(1:3, each = 3),
  values = runif(9),
  x = values,
  id = rep(c("a", "b", "c"), times = 3)
)

p1 <- ggplot(df, aes(week, values, colour = id)) +
  geom_line() +
  gghighlight(id == "a")
#> Warning: Tried to calculate with group_by(), but the calculation failed.
#> Falling back to ungrouped filter operation...
#> label_key: id

p2 <- ggplot(df, aes(week, x, colour = id)) +
  geom_line() +
  gghighlight(id == "a")
#> Warning: Tried to calculate with group_by(), but the calculation failed.
#> Falling back to ungrouped filter operation...
#> label_key: id

p1 * p2
```

![](https://i.imgur.com/4lQaJYX.png)

<sup>Created on 2021-06-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>