### PR TITLE
Use new location of guides

### DIFF
--- a/tests/testthat/test-gghighlight.R
+++ b/tests/testthat/test-gghighlight.R
@@ -63,7 +63,11 @@ test_that("gghighlight() works with the plot with one layer, grouped", {
     p_highlighted <- p + gghighlight(mean(value) > 1, use_direct_label = FALSE)
     expect_equal(p_highlighted$data, d_sieved)
     expect_equal_layers(p_highlighted$layers, list(l_bleached, l_sieved))
-    expect_equal(p_highlighted$guides, NULL)
+    if (utils::packageVersion("ggplot2") <= "3.4.2") {
+      expect_equal(p_highlighted$guides, NULL)
+    } else {
+      expect_equal(p_highlighted$guides$guides, NULL)
+    }
   }
 
   # with labels
@@ -78,7 +82,11 @@ test_that("gghighlight() works with the plot with one layer, grouped", {
     p_highlighted <- p + gghighlight(mean(value) > 1, use_direct_label = TRUE)
     expect_equal(p_highlighted$data, d_sieved)
     expect_equal_layers(p_highlighted$layers, list(l_bleached, l_sieved, l_label))
-    expect_equal(p_highlighted$guides, list(colour = "none", fill = "none"))
+    if (utils::packageVersion("ggplot2") <= "3.4.2") {
+      expect_equal(p_highlighted$guides, list(colour = "none", fill = "none"))
+    } else {
+      expect_equal(p_highlighted$guides$guides, list(colour = "none", fill = "none"))
+    }
   }
 })
 


### PR DESCRIPTION
Hi Hiroaki,

As you might've noticed, the guide system in ggplot2 has been updated, which broke a few of your tests.
This PR fixes these tests by updating the location where guides are tested (depending on ggplot2 version).

Best,
Teun