### PR TITLE
Remove a workaround for jitter in ggplot2 <3.3.4

### DIFF
--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -316,8 +316,6 @@ clone_layer <- function(layer, layer_name_suffix = NULL) {
   new_layer
 }
 
-clone_position <- clone_layer
-
 calculate_group_info <- function(data, mapping, extra_vars = NULL) {
   mapping <- purrr::compact(mapping)
   # the calculation may be possible only in the ggplot2 context (e.g. stat()).

--- a/R/label.R
+++ b/R/label.R
@@ -202,13 +202,6 @@ generate_label_for_point <- function(layer, label_key, label_params, max_labels)
   mapping <- layer$mapping
   mapping$label <- label_key
 
-  if (inherits(layer$position, "PositionJitter") && is.null(layer$position$seed)) {
-    # FIXME when this is fixed on upstream: https://github.com/tidyverse/ggplot2/issues/2507
-    position <- clone_position(layer$position)
-    position$seed <- sample.int(.Machine$integer.max, 1L)
-    layer$position <- position
-  }
-
   label_params$position <- layer$position
 
   inject(ggrepel::geom_label_repel(mapping, layer$data, !!!label_params))


### PR DESCRIPTION
Now that gghighlight requires ggplot2 3.3.6, this workaround for https://github.com/tidyverse/ggplot2/issues/2507 is not needed because it's fixed in ggplot2 3.3.4 by https://github.com/tidyverse/ggplot2/pull/4413