### PR TITLE
Ink should be always greyed?

### DIFF
--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -435,18 +435,13 @@ bleach_layer <- function(layer, group_info, unhighlighted_params, unhighlighted_
 
 
 default_unhighlighted_colour <- function(theme = list()) {
-  geom <- theme$geom
-  if (utils::packageVersion("ggplot2") <= "3.5.1" || is.null(geom)) {
-    return("#BEBEBEB2")
-  }
-
   # ink is greyed, while paper doesn't
-  ink <- grDevices::col2rgb(scales::col2hcl(geom$ink, c = 0) %||% "black")
-  paper <- grDevices::col2rgb(geom$paper %||% "white")
+  ink <- grDevices::col2rgb(scales::col2hcl(theme$geom$ink %||% "black", c = 0))
+  paper <- grDevices::col2rgb(theme$geom$paper %||% "white")
 
   # cf. ggplot2:::col_mix
   # 0.745098 = col2rgb("grey") / col2rgb("white")
-  new <- (0.254902 * ink + 0.745098 * paper)[,1] / 255
+  new <- (0.254902 * paper + 0.745098 * ink)[,1] / 255
   grDevices::rgb(new["red"], new["green"], new["blue"], alpha = 0.698)
 }
 

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -440,12 +440,14 @@ default_unhighlighted_colour <- function(theme = list()) {
     return("#BEBEBEB2")
   }
 
-  # cf. ggplot2:::col_mix
-  ink <- grDevices::col2rgb(geom$ink %||% "black")
+  # ink is greyed, while paper doesn't
+  ink <- grDevices::col2rgb(scales::muted(geom$ink, c = 0) %||% "black")
   paper <- grDevices::col2rgb(geom$paper %||% "white")
+
+  # cf. ggplot2:::col_mix
   # 0.745098 = col2rgb("grey") / col2rgb("white")
   new <- (0.254902 * paper + 0.745098 * ink)[,1]
-  grDevices::rgb(new["red"], new["green"], new["blue"], alpha = 76, maxColorValue = 255)
+  grDevices::rgb(new["red"], new["green"], new["blue"], alpha = 178.5, maxColorValue = 255)
 }
 
 get_default_aes_param <- function(aes_param_name, geom, mapping, unhighlighted_colour) {

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -441,7 +441,7 @@ default_unhighlighted_colour <- function(theme = list()) {
 
   # cf. ggplot2:::col_mix
   # 0.745098 = col2rgb("grey") / col2rgb("white")
-  new <- (0.254902 * paper + 0.745098 * ink)[,1] / 255
+  new <- (0.254902 * ink + 0.745098 * paper)[,1] / 255
   grDevices::rgb(new["red"], new["green"], new["blue"], alpha = 0.698)
 }
 

--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -441,13 +441,13 @@ default_unhighlighted_colour <- function(theme = list()) {
   }
 
   # ink is greyed, while paper doesn't
-  ink <- grDevices::col2rgb(scales::muted(geom$ink, c = 0) %||% "black")
+  ink <- grDevices::col2rgb(scales::col2hcl(geom$ink, c = 0) %||% "black")
   paper <- grDevices::col2rgb(geom$paper %||% "white")
 
   # cf. ggplot2:::col_mix
   # 0.745098 = col2rgb("grey") / col2rgb("white")
-  new <- (0.254902 * paper + 0.745098 * ink)[,1]
-  grDevices::rgb(new["red"], new["green"], new["blue"], alpha = 178.5, maxColorValue = 255)
+  new <- (0.254902 * ink + 0.745098 * paper)[,1] / 255
+  grDevices::rgb(new["red"], new["green"], new["blue"], alpha = 0.698)
 }
 
 get_default_aes_param <- function(aes_param_name, geom, mapping, unhighlighted_colour) {


### PR DESCRIPTION
``` r
devtools::load_all("~/GitHub/gghighlight/")
#> ℹ Loading gghighlight
#> Loading required package: ggplot2

do_plot <- function(ink = "black", paper = "white") {
  p <- ggplot(mtcars, aes(wt, mpg)) + 
    geom_point(size = 10) +
    theme(
      geom = element_geom(ink = ink, paper = paper),
      plot.background = element_rect(fill = paper),
      panel.background = element_rect(fill = paper)
    ) +
    gghighlight(mpg < 25)
}

print(do_plot())
```

![](https://i.imgur.com/gGiNmcR.png)<!-- -->

``` r
print(do_plot("purple"))
```

![](https://i.imgur.com/71szJkG.png)<!-- -->

``` r
print(do_plot("white", "black"))
```

![](https://i.imgur.com/kQyqjSl.png)<!-- -->

``` r
print(do_plot("white", "red"))
```

![](https://i.imgur.com/2gziKlo.png)<!-- -->

<sup>Created on 2024-09-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
