### PR TITLE
Change unhighlighted colour when ink is lighter than paper

### DIFF
--- a/R/gghighlight.R
+++ b/R/gghighlight.R
@@ -435,13 +435,24 @@ bleach_layer <- function(layer, group_info, unhighlighted_params, unhighlighted_
 
 
 default_unhighlighted_colour <- function(theme = list()) {
-  # ink is greyed, while paper doesn't
-  ink <- grDevices::col2rgb(scales::col2hcl(theme$geom$ink %||% "black", c = 0))
-  paper <- grDevices::col2rgb(theme$geom$paper %||% "white")
+  ink <- theme$geom$ink %||% "black"
+  paper <- theme$geom$paper %||% "white"
+
+  ink_bleached <- scales::col2hcl(ink, c = 0)
+  paper_bleached <- scales::col2hcl(paper, c = 0)
+
+  # TODO: flip the color based on the relationship of ink and paper. Can this 
+  #       heuristic removed? I think there should be some theory for this...
+  if (ink_bleached < paper_bleached) {
+    ratio <- 0.254902
+  } else {
+    # 0.745098 = col2rgb("grey") / col2rgb("white")
+    ratio <- 0.745098
+  }
 
   # cf. ggplot2:::col_mix
-  # 0.745098 = col2rgb("grey") / col2rgb("white")
-  new <- (0.254902 * ink + 0.745098 * paper)[,1] / 255
+  # ink is greyed, while paper doesn't
+  new <- (ratio * grDevices::col2rgb(ink_bleached) + (1 - ratio) * grDevices::col2rgb(paper))[,1] / 255
   grDevices::rgb(new["red"], new["green"], new["blue"], alpha = 0.698)
 }
 


### PR DESCRIPTION
``` r
devtools::load_all("~/GitHub/gghighlight/")
#> ℹ Loading gghighlight
#> Loading required package: ggplot2

p1 <- ggplot(mtcars, aes(wt, mpg)) + 
  geom_point(size = 5) +
  theme(geom = element_geom(ink = "purple")) +
  gghighlight(mpg < 25)

do_plot <- function(ink = "black", paper = "white") {
  p <- ggplot(mtcars, aes(wt, mpg)) + 
    geom_point(size = 5) +
    theme(
      geom = element_geom(ink = ink, paper = paper),
      plot.background = element_rect(fill = paper),
      panel.background = element_rect(fill = paper)
    ) +
    gghighlight(mpg < 25)
}

p2 <- do_plot()
p3 <- do_plot("purple")
p4 <- do_plot("white", "black")
p5 <- do_plot("white", "red")
p6 <- do_plot("blue", "red")

patchwork::wrap_plots(p1, p2, p3, p4, p5, p6)
```

![](https://i.imgur.com/Akze04r.png)<!-- -->

<sup>Created on 2024-09-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
